### PR TITLE
Findandreplace ignoreblanks

### DIFF
--- a/lib/lang/en/phrases/z_zora_batch_edit.xml
+++ b/lib/lang/en/phrases/z_zora_batch_edit.xml
@@ -21,6 +21,7 @@
   <epp:phrase id="Plugin/Screen/ZoraBatchEdit:actionopt:append">Append new value</epp:phrase>
   <epp:phrase id="Plugin/Screen/ZoraBatchEdit:actionopt:replace">Replace value with</epp:phrase>
   <epp:phrase id="Plugin/Screen/ZoraBatchEdit:actionopt:findreplace">Find and Replace value</epp:phrase>
+  <epp:phrase id="Plugin/Screen/ZoraBatchEdit:actionopt:findreplace_ignoreblanks">Find and Replace value (retain original if blank)</epp:phrase>
   <epp:phrase id="Plugin/Screen/ZoraBatchEdit:invalid_cache">The search expression could not be found - you will need to re-do your search and start again.</epp:phrase>
   <epp:phrase id="Plugin/Screen/ZoraBatchEdit:no_changes">You attempted to apply some changes but didn't specify any actions to take?</epp:phrase>
   <epp:phrase id="Plugin/Screen/ZoraBatchEdit:applied">The following changes were made: <epc:pin name="changes"/></epp:phrase>
@@ -30,8 +31,9 @@
   <epp:phrase id="Plugin/Screen/ZoraBatchEdit:applied_append">Appended "<epc:pin name="value"/>" onto <em><epc:pin name="fieldname"/></em>.</epp:phrase>
   <epp:phrase id="Plugin/Screen/ZoraBatchEdit:applied_replace">Replaced existing value in <em><epc:pin name="fieldname"/></em> with "<epc:pin name="value"/>".</epp:phrase>
   <epp:phrase id="Plugin/Screen/ZoraBatchEdit:applied_findreplace">Replaced existing value in <em><epc:pin name="fieldname"/></em> matching "<epc:pin name="value"/>" with "<epc:pin name="replace"/>".</epp:phrase>
+  <epp:phrase id="Plugin/Screen/ZoraBatchEdit:applied_findreplace_ignoreblanks">Replaced existing value in <em><epc:pin name="fieldname"/></em> matching "<epc:pin name="value"/>" with "<epc:pin name="replace"/>".</epp:phrase>
   <epp:phrase id="Plugin/Screen/ZoraBatchEdit:applying_to">Applying batch alterations to <epc:pin name="count" /> items (only first <epc:pin name="showing" /> shown):</epp:phrase>
   <epp:phrase id="eprint_fieldname_batchedit_remove" />
-  <epp:phrase id="Plugin/Screen/ZoraBatchEdit:Summary">Summary: Cleared: <epc:pin name="clear" />  Deleted: <epc:pin name="delete" /> Inserted: <epc:pin name="insert" /> Appended: <epc:pin name="append" /> Find/Replace: <epc:pin name="findreplace" /> Replaced:  <epc:pin name="replace" /> of a possible total: <epc:pin name="count" /></epp:phrase>
+  <epp:phrase id="Plugin/Screen/ZoraBatchEdit:Summary">Summary: Cleared: <epc:pin name="clear" />  Deleted: <epc:pin name="delete" /> Inserted: <epc:pin name="insert" /> Appended: <epc:pin name="append" /> Find/Replace: <epc:pin name="findreplace" /> Find/Replace (retaining original if blank): <epc:pin name="findreplace_ignoreblanks" /> Replaced:  <epc:pin name="replace" /> of a possible total: <epc:pin name="count" /></epp:phrase>
 
 </epp:phrases>

--- a/lib/plugins/EPrints/Plugin/Screen/ZoraBatchEdit.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/ZoraBatchEdit.pm
@@ -20,7 +20,6 @@ use EPrints::Plugin::Screen;
 @ISA = ( 'EPrints::Plugin::Screen' );
 
 use strict;
-use Data::Dumper;
 
 sub new
 {
@@ -504,10 +503,6 @@ sub ajax_edit
 					my $values = [];
 					foreach my $o_val ( @$orig_value )
 					{
-#                        print STDERR "SEARCH: ".Dumper($value)."\n";
-#                        print STDERR "ORIGINAL: ".Dumper($o_val)."\n";
-#                        print STDERR "REPLACE: ".Dumper($replace)."\n";
-
 						if ( 0 == cmp_deeply($value, $o_val ) )
 						{
                             #instead of sticking in replace (user input) we want to stick in the difference between replace and dataobj

--- a/lib/static/javascript/auto/zora_screen_batchedit.js
+++ b/lib/static/javascript/auto/zora_screen_batchedit.js
@@ -11,7 +11,8 @@ function EPJS_BatchEditActionSelect( selectPrefix, divPrefix )
 		if ( null != selectObj && null != divObj ) {
 			var selectedIndex = selectObj.selectedIndex;
 			var selectedVal = selectObj.options[selectedIndex].value;
-			if ( null != selectedVal && selectedVal == "findreplace" ) {
+            console.log("SelectedVal: ",selectedVal);
+			if ( null != selectedVal && (selectedVal == "findreplace" || selectedVal == "findreplace_ignoreblanks")) {
 				divObj.setStyle({visibility: 'visible'});
 				divObj.setStyle({display: 'block'});
 			} else {


### PR DESCRIPTION
Hi Martin,

I've added a version of find and replace that will retain the original values of the sub fields in a compound, if there are no values supplied for those sub-fields. I've made this an additional action, as there is still value in the find and replace action that does blank fields too.

Rory